### PR TITLE
Implemented configurable Rune Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This mod allows you to build "Runes", which are 5x5x1 blocks of obsidian. You then create a signature for the Rune, which binds it to other Runes with the same signature.
+This mod allows you to build "Runes", which are typically 5x5x1 blocks of obsidian. You then create a signature for the Rune, which binds it to other Runes with the same signature.
 
 ## Blocks
 
@@ -28,7 +28,7 @@ This mod adds a single structure: The Rune.
 
 ### Rune
 
-Players construct the Rune and utilize it to teleport to other Runes with the same signature. A Rune is a 5x5x1 structure (horizontal). The following diagram outlines the structure of a Rune (note that the dirt blocks can actually be any material):
+Players construct the Rune and utilize it to teleport to other Runes with the same signature. A Rune is typically a 5x5x1 structure (horizontal). The following diagram outlines the structure of a Rune (note that the dirt blocks can actually be any material):
 
 #### Recipe:
 
@@ -81,3 +81,36 @@ If you do not see a Lightning strike when you attempt to activate the Rune, it m
 Once you have constructed and activated two or more Runes with the same signature, you can teleport between them by right clicking the Rune Core in the center of the Rune.
 
 When you use a Rune to teleport, you will be transported to the next Rune with the same signature. You will be transported to each Rune with the same signature in the same order that each Rune was activated.
+
+## Configuration
+
+### Rune Size
+
+By default the rune size is 5. Values of 3 or more are supported. The value must be an odd integer. The smallest valid rune size is 3. You can change this value via the runeSize configuration option of the general section in the blink.cfg file:
+
+```
+# Configuration file
+
+general {
+    # The size that valid runes must be. Must be an odd integer >= 3.
+    I:runeSize=5
+}
+```
+
+For example, a rune of size 3 would be constructed as follows:
+
+#### Recipe:
+
+![Image](doc/images/obsidian.png)
+![Image](doc/images/dirt.png)
+![Image](doc/images/obsidian.png)
+
+![Image](doc/images/dirt.png)
+![Image](src/main/resources/assets/blink/textures/blocks/runecore.png)
+![Image](doc/images/dirt.png)
+
+![Image](doc/images/obsidian.png)
+![Image](doc/images/dirt.png)
+![Image](doc/images/obsidian.png)
+
+Note: This config file will be generated when you first launch Minecraft with the mod installed.

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.0.1"
+version = "1.1.0"
 group= "com.monkeyinabucket.forge.blink"
 archivesBaseName = "blink"
 

--- a/src/main/java/com/monkeyinabucket/forge/blink/block/RuneCore.java
+++ b/src/main/java/com/monkeyinabucket/forge/blink/block/RuneCore.java
@@ -1,5 +1,6 @@
 package com.monkeyinabucket.forge.blink.block;
 
+import com.monkeyinabucket.forge.blink.Blink;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.creativetab.CreativeTabs;
@@ -61,10 +62,11 @@ public class RuneCore extends Block {
   }
 
   /**
-   * Determines if the specified Block is the center of a rune (has a
-   * "Rune Shell"). Currently a rune shell is defined as the obsidian shell of a
-   * BlinkRune: (Y == RuneCore, X == Obsidian)
-   * 
+   * Determines if the specified Block is the center of a rune (has a "Rune Shell"). Currently a rune shell is defined
+   * as the obsidian shell of a BlinkRune: (Y == RuneCore, X == Obsidian)
+   *
+   * For example, if Blink.runeSize is 5, a valid rune would be:
+   *
    * <pre>
    *  X X X X X
    *  X X   X X
@@ -82,17 +84,19 @@ public class RuneCore extends Block {
   protected boolean hasRuneShell(World world, int x, int y, int z) {
     // We were passed the coordinates for the center, but we need to start at the
     // North/West corner
-    x -= 2;
-    z -= 2;
+    x -= Blink.halfRuneSize;
+    z -= Blink.halfRuneSize;
+
+    int center = Blink.halfRuneSize;
 
     // loop over the columns and rows, checking for obsidian
     // note: the first row is row 0, not row 1. same for columns.
-    for (int col = 0; col < 5; ++col) {
-      for (int row = 0; row < 5; ++row) {
+    for (int col = 0; col < Blink.runeSize; ++col) {
+      for (int row = 0; row < Blink.runeSize; ++row) {
         Block block = world.getBlock(x + col, y, z + row);
 
-        // column 3, row 2 & 4 and , column 2 & 4, cannot be obsidian
-        if ((col == 2 && (row == 1 || row == 3)) || row == 2 && (col == 1 || col == 3)) {
+        // blocks immediately north, south, east & west of the center cannot be obsidian
+        if ((col == center && (row == center - 1 || row == center + 1)) || row == center && (col == center - 1 || col == center + 1)) {
           if (block != null && block.equals(Blocks.obsidian)) {
             return false;
           }
@@ -101,7 +105,7 @@ public class RuneCore extends Block {
         }
 
         // center block is the Rune Core, so we ignore it
-        if (col == 2 && row == 2) {
+        if (col == center && row == center) {
           continue;
         }
 

--- a/src/main/java/com/monkeyinabucket/forge/blink/rune/Rune.java
+++ b/src/main/java/com/monkeyinabucket/forge/blink/rune/Rune.java
@@ -3,6 +3,7 @@ package com.monkeyinabucket.forge.blink.rune;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import com.monkeyinabucket.forge.blink.Blink;
 import com.monkeyinabucket.forge.world.Location;
 
 /**
@@ -20,12 +21,12 @@ public class Rune {
    * @return the list of locations
    */
   public Collection<Location> getParts() {
-    int startZ = loc.z - 2;
-    int startX = loc.x - 2;
+    int startZ = loc.z - Blink.halfRuneSize;
+    int startX = loc.x - Blink.halfRuneSize;
 
     ArrayList<Location> parts = new ArrayList<Location>();
-    for (int col = 0; col < 5; ++col) {
-      for (int row = 0; row < 5; ++row) {
+    for (int col = 0; col < Blink.runeSize; ++col) {
+      for (int row = 0; row < Blink.runeSize; ++row) {
         Location nextLoc = new Location(loc.world, startX + row, loc.y, startZ + col);
 
         parts.add(nextLoc);
@@ -43,8 +44,8 @@ public class Rune {
    */
   public boolean isPart(Location otherLoc) {
     return otherLoc.world.provider.dimensionId == loc.world.provider.dimensionId
-        && otherLoc.y == loc.y && otherLoc.z >= loc.z - 2 && otherLoc.z <= loc.z + 2
-        && otherLoc.x >= loc.x - 2 && otherLoc.x <= loc.x + 2;
+        && otherLoc.y == loc.y && otherLoc.z >= loc.z - Blink.halfRuneSize && otherLoc.z <= loc.z + Blink.halfRuneSize
+        && otherLoc.x >= loc.x - Blink.halfRuneSize && otherLoc.x <= loc.x + Blink.halfRuneSize;
   }
 
   /**


### PR DESCRIPTION
Added a general config setting called runeSize, that can be used to change the rune size from the default 5x5 to something else.

The rune size must be an odd integer, that is greater than or equal to 3.