### PR TITLE
Fix assumption of saves directory

### DIFF
--- a/src/main/java/com/monkeyinabucket/forge/blink/Blink.java
+++ b/src/main/java/com/monkeyinabucket/forge/blink/Blink.java
@@ -1,6 +1,8 @@
 package com.monkeyinabucket.forge.blink;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import com.google.gson.*;
@@ -194,11 +196,13 @@ public class Blink {
     MinecraftForge.EVENT_BUS.register(this);
     FMLCommonHandler.instance().bus().register(this);
 
-    legacySaveFile = "saves" + "/" + MinecraftServer.getServer().getFolderName() + '/'
-        + LEGACY_SAVE_FILE_NAME;
+    String path = Files.isDirectory(Paths.get("saves"))
+        ? "saves/" + MinecraftServer.getServer().getFolderName() + '/'
+        : MinecraftServer.getServer().getFolderName() + '/';
 
-    jsonSaveFile = "saves" + "/" + MinecraftServer.getServer().getFolderName() + '/'
-        + JSON_SAVE_FILE_NAME;
+    legacySaveFile = path + LEGACY_SAVE_FILE_NAME;
+
+    jsonSaveFile = path + JSON_SAVE_FILE_NAME;
   }
 
   /**


### PR DESCRIPTION
Problem:
The mod is assuming that all worlds are saved in the "saves" directories. This is true when running locally, but is not true when running in a dedicated server environment.

Fix:
I modified the logic to check for the existence of a "saves" directory. If it exists, the mod will attempt to save/load rune data from world directories within the saves directory. If the "saves" directory does not exist, the mod will assume that the world directories are stored within the root of the working directory.