### PR TITLE
Save runes on rune creation

### DIFF
--- a/src/main/java/com/monkeyinabucket/forge/blink/block/RuneCore.java
+++ b/src/main/java/com/monkeyinabucket/forge/blink/block/RuneCore.java
@@ -154,6 +154,8 @@ public class RuneCore extends Block {
       runeManager.addRune(rune);
 
       rune.onCreate();
+
+      Blink.instance.saveRunes();
     }
   }
 }


### PR DESCRIPTION
Problem:
Currently the runes are only saved when the server cleanly shuts down. If the server crashes for any reason then the runes will not be saved.

Fix:
The runes will now be saved whenever a new rune is created.