### PR TITLE
Fix Blink instance is not injected

### DIFF
--- a/src/main/java/com/monkeyinabucket/forge/blink/Blink.java
+++ b/src/main/java/com/monkeyinabucket/forge/blink/Blink.java
@@ -83,7 +83,7 @@ public class Blink {
 
   public static Block runecore;
 
-  @Instance(value = "Blink")
+  @Instance(value = "blink")
   public static Blink instance;
 
   @EventHandler


### PR DESCRIPTION
# Problem:
Some versions of forge are not injecting the Blink instance.

# Cause:
It seems that the instance annotation requires the mod id and not the mod name. The mod id is lowercase, but the name has an uppercase first character.

# Fix:
I modified the annotation to use the lowercase mod id.